### PR TITLE
Add Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ pip install -r requirements.txt
 # Note: Version 2.7.4.post1 is specified for compatibility with CUDA 12.4.
 # Feel free to use a newer version if you use CUDA 12.6 or they fixed this compatibility issue.
 # OmniGen2 runs even without flash-attn, though we recommend install it for best performance.
+# For Windows OS support install triton-windows
+# pip install triton-windows
 pip install flash-attn==2.7.4.post1 --no-build-isolation
 ```
 

--- a/README.md
+++ b/README.md
@@ -96,8 +96,6 @@ pip install -r requirements.txt
 # Note: Version 2.7.4.post1 is specified for compatibility with CUDA 12.4.
 # Feel free to use a newer version if you use CUDA 12.6 or they fixed this compatibility issue.
 # OmniGen2 runs even without flash-attn, though we recommend install it for best performance.
-# For Windows OS support install triton-windows
-# pip install triton-windows
 pip install flash-attn==2.7.4.post1 --no-build-isolation
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ omegaconf
 python-dotenv
 ninja
 ipykernel
+wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ python-dotenv
 ninja
 ipykernel
 wheel
+triton-windows; sys_platform == "win32"


### PR DESCRIPTION
Updating the requirements file to add Windows support. When not using conda Wheel is required to be directly specified and triton-windows is required for flash attention support. Specified only to install it on windows based systems.